### PR TITLE
Aprimora layout dos cards de projeto e feedback de foco na navegação

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,11 +268,15 @@ ol li::before {
     font-size: var(--font-size-h4-card); /* Usando variável */
     border-bottom: 2px dashed var(--color-yellow); padding-bottom: 12px;
     line-height: 1.4;
+    overflow-wrap: break-word;
+    word-wrap: break-word; /* fallback mais antigo */
 }
 .project-card p {
     font-size: var(--font-size-sm); /* Usando variável */
     line-height: 1.65; display: flex; align-items: flex-start;
     gap: 10px; /* Mais espaço */ margin-bottom: 12px;
+    overflow-wrap: break-word;
+    word-wrap: break-word; /* fallback mais antigo */
 }
 .project-card p strong {
     color: var(--color-orange); min-width: 150px; /* Aumentado */
@@ -496,7 +500,12 @@ footer::before {
     .quiz-nav-button { width: 90%; justify-content: center; }
     .project-card h4 { font-size: 1.05rem; } /* Reduzido para telas menores */
     .project-card p { font-size: 0.78rem; } /* Reduzido para telas menores */
-    .project-card p strong { min-width: 120px; }
+    /* Ajuste para evitar empilhamento de texto em telas médias */
+    .project-card p strong {
+        min-width: auto; /* Alterado de 120px */
+        display: block;
+        margin-bottom: 3px; /* Adicionado para consistência com <480px */
+    }
 }
 @media (max-width: 480px) {
     body { font-size: 14px; }
@@ -525,4 +534,11 @@ footer::before {
 @keyframes fadeInCard {
     from { opacity: 0; transform: translateY(15px); }
     to { opacity: 1; transform: translateY(0); }
+}
+
+/* Melhor feedback de foco para navegação via teclado */
+nav a:focus-visible {
+    outline: 2px dashed var(--color-red-pink);
+    outline-offset: 3px;
+    background-color: rgba(228, 51, 89, 0.08);
 }


### PR DESCRIPTION
Este commit implementa as seguintes melhorias em resposta ao seu feedback:

1.  **Melhora o Layout Responsivo dos Cards de Projeto (index.html/style.css):**
    *   Para resolver problemas de "empilhamento" de texto em telas menores e médias (até 768px de largura), os rótulos dentro dos cards de projeto (ex: "Foco Matemático:", "Interdisciplinaridade:") foram ajustados para `display: block`. Isso garante que o rótulo e seu texto descritivo ocupem linhas separadas, melhorando significativamente a legibilidade.
    *   Adicionada a propriedade `overflow-wrap: break-word;` aos títulos (h4) e parágrafos (p) dos cards de projeto para permitir a quebra de palavras longas, evitando que estas quebrem o layout do card.

2.  **Aprimora Feedback Visual de Foco (style.css):**
    *   Adicionada uma regra CSS para o pseudo-seletor `:focus-visible` nos links da navegação principal (`nav a`). Isso fornece um indicador visual claro (outline e background sutil) para usuários que navegam via teclado, melhorando a acessibilidade e a sua experiência sem afetar o estilo para cliques de mouse.

Estas alterações visam proporcionar uma experiência de usuário mais robusta e agradável, especialmente em dispositivos com telas menores, e melhorar a acessibilidade da navegação.