### PR TITLE
Fix: Improve carousel width calculation and robustness.

### DIFF
--- a/carousel.js
+++ b/carousel.js
@@ -37,7 +37,10 @@ document.addEventListener('DOMContentLoaded', () => {
     function updateItemWidthAndSlider() {
         const wrapper = document.querySelector('.carousel-slider-wrapper');
         if (wrapper) {
-            itemWidth = wrapper.offsetWidth; // Largura do item é a largura do wrapper
+            console.log("Carousel debug: wrapper.offsetWidth =", wrapper.offsetWidth, "totalItems =", totalItems);
+            itemWidth = wrapper.clientWidth; // Largura do item é a largura do wrapper
+            console.log("Carousel debug: itemWidth (from clientWidth) =", itemWidth);
+            if (itemWidth <= 0) { console.warn("Carousel warning: itemWidth is 0 or less. Carousel may not display correctly."); return; }
             // Ajusta a largura de cada item do carrossel para 100% do wrapper
             items.forEach(item => {
                 item.style.minWidth = `${itemWidth}px`;


### PR DESCRIPTION
- Changed carousel item width calculation to use `clientWidth` of the wrapper for more accurate sizing relative to the content area.
- Added diagnostic logging for item width and total items.
- Included a safeguard to prevent errors if calculated itemWidth is zero or negative.

These changes aim to resolve issues where the carousel might appear stuck on the first card due to incorrect width calculations and to make the overall carousel logic more robust.